### PR TITLE
Increase difficulty of several microgames

### DIFF
--- a/src/game/server/entities/character.cpp
+++ b/src/game/server/entities/character.cpp
@@ -367,14 +367,18 @@ void CCharacter::FireWeapon()
 	// check for ammo
 	if(!m_aWeapons[m_Core.m_ActiveWeapon].m_Ammo)
 	{
-		/*// 125ms is a magical limit of how fast a human can click
-		m_ReloadTimer = 125 * Server()->TickSpeed() / 1000;
-		GameServer()->CreateSound(m_Pos, SOUND_WEAPON_NOAMMO);*/
-		// Timer stuff to avoid shrieking orchestra caused by unfreeze-plasma
-		if(m_PainSoundTimer<=0)
+		if (m_FreezeTime > 0)
 		{
-				m_PainSoundTimer = 1 * Server()->TickSpeed();
-				GameServer()->CreateSound(m_Pos, SOUND_PLAYER_PAIN_LONG, Teams()->TeamMask(Team(), -1, m_pPlayer->GetCID()));
+			// Timer stuff to avoid shrieking orchestra caused by unfreeze-plasma
+			if(m_PainSoundTimer<=0)
+			{
+					m_PainSoundTimer = 1 * Server()->TickSpeed();
+					GameServer()->CreateSound(m_Pos, SOUND_PLAYER_PAIN_LONG, Teams()->TeamMask(Team(), -1, m_pPlayer->GetCID()));
+			}
+		} else {
+			// 125ms is a magical limit of how fast a human can click
+			m_ReloadTimer = 125 * Server()->TickSpeed() / 1000;
+			GameServer()->CreateSound(m_Pos, SOUND_WEAPON_NOAMMO, Teams()->TeamMask(Team(), -1, m_pPlayer->GetCID()));
 		}
 		return;
 	}
@@ -604,8 +608,8 @@ void CCharacter::FireWeapon()
 
 	m_AttackTick = Server()->Tick();
 
-	/*if(m_aWeapons[m_Core.m_ActiveWeapon].m_Ammo > 0) // -1 == unlimited
-		m_aWeapons[m_Core.m_ActiveWeapon].m_Ammo--;*/
+	if(m_aWeapons[m_Core.m_ActiveWeapon].m_Ammo > 0) // -1 == unlimited
+		m_aWeapons[m_Core.m_ActiveWeapon].m_Ammo--;
 
 	if(!m_ReloadTimer)
 	{

--- a/src/game/server/entities/projectile.cpp
+++ b/src/game/server/entities/projectile.cpp
@@ -328,11 +328,13 @@ void CProjectile::Tick()
 					// explosion
 					GameServer()->CreateExplosion(ColPos, m_Owner, m_Weapon, true, (!pTargetChr ? -1 : pTargetChr->Team()),
 					(m_Owner != -1)? TeamMask : -1LL);
+				} else {
+					GameServer()->CreateExplosion(ColPos, m_Owner, m_Weapon, false, (!pTargetChr ? -1 : pTargetChr->Team()),
+					(m_Owner != -1)? TeamMask : -1LL);
 				}
-				GameServer()->CreateExplosion(ColPos, m_Owner, m_Weapon, false, (!pTargetChr ? -1 : pTargetChr->Team()),
-				(m_Owner != -1)? TeamMask : -1LL);
+
 				GameServer()->CreateSound(ColPos, m_SoundImpact,
-				(m_Owner != -1)? TeamMask : -1LL);
+					(m_Owner != -1)? TeamMask : -1LL);
 			}
 		}
 		else if(pTargetChr && m_Freeze && ((m_Layer == LAYER_SWITCH && GameServer()->Collision()->m_pSwitchers[m_Number].m_Status[pTargetChr->Team()]) || m_Layer != LAYER_SWITCH))

--- a/src/game/server/entities/projectile.cpp
+++ b/src/game/server/entities/projectile.cpp
@@ -117,6 +117,8 @@ vec2 CProjectile::GetPos(float Time)
 
 void CProjectile::Tick()
 {
+	CGameControllerWarioWare* controller = ((CGameControllerWarioWare*)GameServer()->m_pController);
+
 	if (m_FootMode && m_Type == WEAPON_GRENADE) // taken from teefoot mod
 	{
 		float PreviousTick = (Server()->Tick()-m_StartTick-1)/(float)Server()->TickSpeed();
@@ -145,7 +147,7 @@ void CProjectile::Tick()
 					TeamMask = OwnerChar->Teams()->TeamMask(OwnerChar->Team(), -1, m_Owner);
 				}
 
-				GameServer()->CreateExplosion(CurPosition, m_Owner, m_Weapon, m_Owner == -1, (!OwnerChar ? -1 : OwnerChar->Team()),
+				GameServer()->CreateExplosion(CurPosition, m_Owner, m_Weapon, false, (!OwnerChar ? -1 : OwnerChar->Team()),
 				(m_Owner != -1)? TeamMask : -1LL);
 				GameServer()->CreateSound(CurPosition, m_SoundImpact,
 				(m_Owner != -1)? TeamMask : -1LL);
@@ -261,7 +263,7 @@ void CProjectile::Tick()
 			}
 			else if (m_FootMode == 2 and TimeAlive > 1.25f) // explode (avoid spawnkill by waiting 1.25sec beforehand)
 			{
-				GameServer()->CreateExplosion(CurPosition, m_Owner, m_Weapon, m_Owner == -1, (!TChar ? -1 : TChar->Team()), -1LL);
+				GameServer()->CreateExplosion(CurPosition, m_Owner, m_Weapon, false, (!TChar ? -1 : TChar->Team()), -1LL);
 				GameServer()->CreateSound(CurPosition, m_SoundImpact, -1LL);
 				GameServer()->m_World.DestroyEntity(this);
 			}
@@ -308,14 +310,26 @@ void CProjectile::Tick()
 	{
 		GameServer()->m_World.DestroyEntity(this);
 	}
+	bool isMGTarget = false;
+	if (controller->inMicroGame() and str_comp(controller->getMicroGame()->m_microgameName, "target") == 0)
+		isMGTarget = true;
 
-	if( ((pTargetChr && (pOwnerChar ? !(pOwnerChar->m_Hit&CCharacter::DISABLE_HIT_GRENADE) : g_Config.m_SvHit || m_Owner == -1 || pTargetChr == pOwnerChar)) || Collide || GameLayerClipped(CurPos)) && !isWeaponCollide)
+	if( ((pTargetChr && (pOwnerChar ? (isMGTarget && pTargetChr->GetPlayer()->GetCID() == MAX_CLIENTS - 1) || !(pOwnerChar->m_Hit&CCharacter::DISABLE_HIT_GRENADE) : g_Config.m_SvHit || m_Owner == -1 || pTargetChr == pOwnerChar)) || Collide || GameLayerClipped(CurPos)) && !isWeaponCollide)
 	{
 		if(m_Explosive/*??*/ && (!pTargetChr || (pTargetChr && (!m_Freeze || (m_Weapon == WEAPON_SHOTGUN && Collide)))))
 		{
 			if (m_Bouncing == 0)
 			{
-				GameServer()->CreateExplosion(ColPos, m_Owner, m_Weapon, m_Owner == -1, (!pTargetChr ? -1 : pTargetChr->Team()),
+				// direct hit only
+				if (isMGTarget) {
+					// force damage
+					if (pTargetChr)
+						pTargetChr->TakeDamage(vec2(0, 0), 1, m_Owner, m_Weapon);
+					// explosion
+					GameServer()->CreateExplosion(ColPos, m_Owner, m_Weapon, true, (!pTargetChr ? -1 : pTargetChr->Team()),
+					(m_Owner != -1)? TeamMask : -1LL);
+				}
+				GameServer()->CreateExplosion(ColPos, m_Owner, m_Weapon, false, (!pTargetChr ? -1 : pTargetChr->Team()),
 				(m_Owner != -1)? TeamMask : -1LL);
 				GameServer()->CreateSound(ColPos, m_SoundImpact,
 				(m_Owner != -1)? TeamMask : -1LL);
@@ -341,6 +355,8 @@ void CProjectile::Tick()
 		}
 		else if (m_Weapon == WEAPON_GUN)
 		{
+			if (isMGTarget && pTargetChr)
+				pTargetChr->TakeDamage(vec2(0, 0), 1, m_Owner, m_Weapon);
 			GameServer()->CreateDamageInd(CurPos, -atan2(m_Direction.x, m_Direction.y), 10, (m_Owner != -1)? TeamMask : -1LL);
 			GameServer()->m_World.DestroyEntity(this);
 		}
@@ -361,7 +377,7 @@ void CProjectile::Tick()
 					TeamMask = pOwnerChar->Teams()->TeamMask(pOwnerChar->Team(), -1, m_Owner);
 			}
 
-			GameServer()->CreateExplosion(ColPos, m_Owner, m_Weapon, m_Owner == -1, (!pOwnerChar ? -1 : pOwnerChar->Team()),
+			GameServer()->CreateExplosion(ColPos, m_Owner, m_Weapon, false, (!pOwnerChar ? -1 : pOwnerChar->Team()),
 			(m_Owner != -1)? TeamMask : -1LL);
 			GameServer()->CreateSound(ColPos, m_SoundImpact,
 			(m_Owner != -1)? TeamMask : -1LL);

--- a/src/game/server/gamecontext.cpp
+++ b/src/game/server/gamecontext.cpp
@@ -158,10 +158,9 @@ int CGameContext::CreateExplosion(vec2 Pos, int Owner, int Weapon, bool NoDamage
 		pEvent->m_X = (int)Pos.x;
 		pEvent->m_Y = (int)Pos.y;
 	}
-/*
+
 	if (!NoDamage)
 	{
-	*/
 		// deal damage
 		CCharacter *apEnts[MAX_CLIENTS];
 		float Radius = 135.0f;
@@ -193,9 +192,10 @@ int CGameContext::CreateExplosion(vec2 Pos, int Owner, int Weapon, bool NoDamage
 				}
 			}
 		}
-	//}
+		return Num;
+	}
 	
-	return Num;
+	return 0;
 }
 
 /*

--- a/src/game/server/gamemodes/WarioWare.cpp
+++ b/src/game/server/gamemodes/WarioWare.cpp
@@ -395,6 +395,16 @@ void CGameControllerWarioWare::winMicroGame(int client)
 	GameServer()->CreateDeath(Char->m_Pos, client);
 }
 
+void CGameControllerWarioWare::killAndLoseMicroGame(int client, int killer, int weapon)
+{
+	CCharacter *Char = GameServer()->GetPlayerChar(client);
+	if (not Char) return;
+	
+	g_Complete[client] = false;
+	float timeLeft = getTimeLength() - getTimer();
+	Char->Die(killer, weapon, timeLeft/1000.0f);
+}
+
 int CGameControllerWarioWare::OnCharacterDeath(class CCharacter *pVictim, class CPlayer *pKiller, int Weapon)
 {
 	if (isInGame() and inMicroGame())

--- a/src/game/server/gamemodes/WarioWare.h
+++ b/src/game/server/gamemodes/WarioWare.h
@@ -58,6 +58,7 @@ public:
 	// warioware
 	void rollMicroGame();
 	void winMicroGame(int client);
+	void killAndLoseMicroGame(int client, int killer = -1, int weapon = -1);
 	void onMicroGameEnd();
 	void nextWarioState();
 	void doGameOver();

--- a/src/game/server/gamemodes/microgames/bombrain.cpp
+++ b/src/game/server/gamemodes/microgames/bombrain.cpp
@@ -114,10 +114,6 @@ void MGBombRain::OnCharacterDamage(int Victim, int Killer, int Dmg, int Weapon)
 {
 	if (Killer == -1 and Weapon == WEAPON_GRENADE) // unlucky guy hit by bomb
 	{
-		CCharacter *Char = GameServer()->GetPlayerChar(Victim);
-		float timeLeft = Controller()->getTimeLength() - Controller()->getTimer();
-
-		Char->Die(Victim, Weapon, timeLeft/1000.f);
-		Controller()->g_Complete[Victim] = false;
+		Controller()->killAndLoseMicroGame(Victim, -1, Weapon);
 	}
 }

--- a/src/game/server/gamemodes/microgames/dontmove.cpp
+++ b/src/game/server/gamemodes/microgames/dontmove.cpp
@@ -47,8 +47,7 @@ void MGDontMove::Tick()
 			if ((not m_Mode and (Char->IsMoving() or Char->GetInput()->m_Hook&1 or Char->GetInput()->m_Fire&1 or Char->GetInput()->m_Jump==1)) or // don't move
 				(m_Mode and (not Char->IsMoving() and (Char->Core()->m_Vel.x < 1 and Char->Core()->m_Vel.x > -1) and (Char->Core()->m_Vel.y < 1 and Char->Core()->m_Vel.y > -1)))) // don't stop moving
 			{
-				Controller()->g_Complete[i] = false;
-				Char->Die(i, WEAPON_WORLD, timeLeft/1000.f);
+				Controller()->killAndLoseMicroGame(i);
 			}
 		}
 	}

--- a/src/game/server/gamemodes/microgames/dontmove.cpp
+++ b/src/game/server/gamemodes/microgames/dontmove.cpp
@@ -3,7 +3,15 @@
 #include <engine/shared/config.h>
 #include "dontmove.h"
 
-const char *modes[2] = {"Don't move!", "Don't stop moving!"};
+const char *modes[7][2] = {
+	{"Don't move!", "Don't stop moving!"},
+	{"Keep still!", "Don't keep still!"},
+	{"Hold your position!", "Keep moving!"},
+	{"Stand still!", "Move your body!"},
+	{"Nobody move!", "Let's move, everybody!"},
+	{"Let's hold, everybody!", "Nobody stay still!"},
+	{"Freeze!", "Keep running!"}
+};
 
 
 MGDontMove::MGDontMove(CGameContext* pGameServer, CGameControllerWarioWare* pController) : Microgame(pGameServer, pController)
@@ -14,8 +22,9 @@ MGDontMove::MGDontMove(CGameContext* pGameServer, CGameControllerWarioWare* pCon
 
 void MGDontMove::Start()
 {
+	m_Phrase = rand() % 2;
 	m_Mode = rand() % 2;			
-	GameServer()->SendBroadcast(modes[m_Mode], -1);
+	GameServer()->SendBroadcast(modes[m_Phrase][m_Mode], -1);
 	Controller()->setPlayerTimers(g_Config.m_WwSndMgDontMove_Offset, g_Config.m_WwSndMgDontMove_Length);
 	for (int i=0; i<MAX_CLIENTS; i++)
 	{

--- a/src/game/server/gamemodes/microgames/dontmove.h
+++ b/src/game/server/gamemodes/microgames/dontmove.h
@@ -22,6 +22,7 @@ public:
 
 private:
 	int m_Mode; // whether it's "don't move" or "don't stop moving"
+	int m_Phrase; // which phrase to use
 };
 
 #endif // _MICROGAME_DONTMOVE_H

--- a/src/game/server/gamemodes/microgames/hitenemy.cpp
+++ b/src/game/server/gamemodes/microgames/hitenemy.cpp
@@ -27,10 +27,7 @@ void MGHitEnemy::Tick()
 
 void MGHitEnemy::OnCharacterDamage(int Victim, int Killer, int Dmg, int Weapon)
 {
-	float timeLeft = Controller()->getTimeLength() - Controller()->getTimer();
-
-	CCharacter *cVictim = GameServer()->GetPlayerChar(Victim);
-	if (cVictim) cVictim->Die(Killer, Weapon, timeLeft/1000.f); // respawn in secs
+	Controller()->killAndLoseMicroGame(Victim, Killer, Weapon);
 }
 
 int MGHitEnemy::OnCharacterDeath(class CCharacter *pVictim, class CPlayer *pKiller, int Weapon)

--- a/src/game/server/gamemodes/microgames/kamikaze.cpp
+++ b/src/game/server/gamemodes/microgames/kamikaze.cpp
@@ -80,10 +80,7 @@ void MGKamikaze::Tick()
 void MGKamikaze::OnCharacterDamage(int Victim, int Killer, int Dmg, int Weapon)
 {
 	if (Weapon != WEAPON_WORLD) return;
-	float timeLeft = Controller()->getTimeLength() - Controller()->getTimer();
-
-	CCharacter *cVictim = GameServer()->GetPlayerChar(Victim);
-	if (cVictim) cVictim->Die(Killer, Weapon, timeLeft/1000.f); // respawn in secs
+	Controller()->killAndLoseMicroGame(Victim, Killer, Weapon);
 }
 
 int MGKamikaze::OnCharacterDeath(class CCharacter *pVictim, class CPlayer *pKiller, int Weapon)

--- a/src/game/server/gamemodes/microgames/ninjasurvival.cpp
+++ b/src/game/server/gamemodes/microgames/ninjasurvival.cpp
@@ -94,9 +94,7 @@ void MGNinjaSurvival::OnCharacterDamage(int Victim, int Killer, int Dmg, int Wea
 
 		if(pVictim->GetHealth() <= 0)
 		{
-			float timeLeft = Controller()->getTimeLength() - Controller()->getTimer();
-			pVictim->Die(Killer, Weapon, timeLeft/1000.f);
-			Controller()->g_Complete[Victim] = false;
+			Controller()->killAndLoseMicroGame(Victim, Killer, Weapon);
 
 			// set attacker's face to happy (taunt!)
 			pKiller->SetEmoteType(EMOTE_HAPPY);

--- a/src/game/server/gamemodes/microgames/reachendnade1.cpp
+++ b/src/game/server/gamemodes/microgames/reachendnade1.cpp
@@ -97,10 +97,7 @@ void MGReachEndNade1::OnCharacterDamage(int Victim, int Killer, int Dmg, int Wea
 {
 	if (Killer == -1 and Weapon == WEAPON_GRENADE)
 	{
-		CCharacter *Char = GameServer()->GetPlayerChar(Victim);
-		float timeLeft = Controller()->getTimeLength() - Controller()->getTimer();
-
-		Char->Die(Victim, Weapon, timeLeft/1000.f);
+		Controller()->killAndLoseMicroGame(Victim, -1, Weapon);
 	}
 }
 

--- a/src/game/server/gamemodes/microgames/reachendnade2.cpp
+++ b/src/game/server/gamemodes/microgames/reachendnade2.cpp
@@ -97,10 +97,7 @@ void MGReachEndNade2::OnCharacterDamage(int Victim, int Killer, int Dmg, int Wea
 {
 	if (Killer == -1 and Weapon == WEAPON_GRENADE)
 	{
-		CCharacter *Char = GameServer()->GetPlayerChar(Victim);
-		float timeLeft = Controller()->getTimeLength() - Controller()->getTimer();
-
-		Char->Die(Victim, Weapon, timeLeft/1000.f);
+		Controller()->killAndLoseMicroGame(Victim, -1, Weapon);
 	}
 }
 

--- a/src/game/server/gamemodes/microgames/simon.cpp
+++ b/src/game/server/gamemodes/microgames/simon.cpp
@@ -4,7 +4,10 @@
 #include "simon.h"
 
 const char *simonNames[] = {"Simon", "Someone"};
-const char *simonModes[] = {"Jump", "Look up", "Look down"};
+const char *simonModes[2][3] = {
+	{"Jump", "Look up", "Look down"},
+	{"Don't jump", "Don't look up", "Don't look down"}
+};
 const float PI = 3.141592653589793f;
 
 MGSimon::MGSimon(CGameContext* pGameServer, CGameControllerWarioWare* pController) : Microgame(pGameServer, pController)
@@ -17,12 +20,13 @@ void MGSimon::Start()
 {
 	m_Someone = rand() % 2; // simon/someone
 	m_SimonMode = rand() % 3; // simons[] array
+	m_SimonNegative = rand() % 2; // do/don't
 	
 	for (int i=0; i<MAX_CLIENTS; i++)
-		Controller()->g_Complete[i] = (m_Someone) ? true : false;
+		Controller()->g_Complete[i] = (m_Someone != m_SimonNegative) ? true : false;
 	
 	char aBuf[96];
-	str_format(aBuf, sizeof(aBuf), "%s says: %s!", simonNames[m_Someone], simonModes[m_SimonMode]);
+	str_format(aBuf, sizeof(aBuf), "%s说： %s！", simonNames[m_Someone], simonModes[m_SimonNegative][m_SimonMode]);
 	GameServer()->SendBroadcast(aBuf, -1);
 
 	Controller()->setPlayerTimers(g_Config.m_WwSndMgSimonSays_Offset, g_Config.m_WwSndMgSimonSays_Length);
@@ -47,17 +51,28 @@ void MGSimon::Tick()
 			CNetObj_PlayerInput* input = Char->GetInput();
 			float angle = -atan2(input->m_TargetY, input->m_TargetX) / PI * 180;
 		
-			if ((m_SimonMode == 0 and input->m_Jump&1) or
+			if ((m_SimonMode == 0 and input->m_Jump&1) or // jump
 				(m_SimonMode == 1 and angle >= 75 and angle < 105) or // up
 				(m_SimonMode == 2 and angle <= -75 and angle > -105)) // down
 			{
-				if (m_Someone) // simon didn't say it
+				if (m_Someone != m_SimonNegative) // simon didn't say it or simon says don't
 				{
 					Controller()->killAndLoseMicroGame(i);
-					GameServer()->SendChatTarget(i, "Simon didn't say it!...");
+					if (m_Someone)
+						GameServer()->SendChatTarget(i, "Simon didn't say it!...");
 				}
 				else
 					Controller()->winMicroGame(i);
+			}
+			
+			// reduced timer for someone says don't
+			if (timeLeft < 2700 && m_SimonNegative && m_Someone) {
+				if (!Controller()->g_Complete[i]) {
+					Controller()->killAndLoseMicroGame(i);
+					if (m_Someone)
+						GameServer()->SendChatTarget(i, "Simon didn't say it!...");
+
+				}
 			}
 		}
 	}

--- a/src/game/server/gamemodes/microgames/simon.cpp
+++ b/src/game/server/gamemodes/microgames/simon.cpp
@@ -53,8 +53,7 @@ void MGSimon::Tick()
 			{
 				if (m_Someone) // simon didn't say it
 				{
-					Controller()->g_Complete[i] = false;
-					Char->Die(i, WEAPON_WORLD, timeLeft/1000.f);
+					Controller()->killAndLoseMicroGame(i);
 					GameServer()->SendChatTarget(i, "Simon didn't say it!...");
 				}
 				else

--- a/src/game/server/gamemodes/microgames/simon.cpp
+++ b/src/game/server/gamemodes/microgames/simon.cpp
@@ -26,7 +26,7 @@ void MGSimon::Start()
 		Controller()->g_Complete[i] = (m_Someone != m_SimonNegative) ? true : false;
 	
 	char aBuf[96];
-	str_format(aBuf, sizeof(aBuf), "%s说： %s！", simonNames[m_Someone], simonModes[m_SimonNegative][m_SimonMode]);
+	str_format(aBuf, sizeof(aBuf), "%s says: %s!", simonNames[m_Someone], simonModes[m_SimonNegative][m_SimonMode]);
 	GameServer()->SendBroadcast(aBuf, -1);
 
 	Controller()->setPlayerTimers(g_Config.m_WwSndMgSimonSays_Offset, g_Config.m_WwSndMgSimonSays_Length);

--- a/src/game/server/gamemodes/microgames/simon.h
+++ b/src/game/server/gamemodes/microgames/simon.h
@@ -23,6 +23,7 @@ public:
 private:
 	int m_Someone; // if "Someone says" then don't do it
 	int m_SimonMode; // look up, look down, jump
+	int m_SimonNegative; // do, don't
 };
 
 #endif // _MICROGAME_SIMON_H

--- a/src/game/server/gamemodes/microgames/target.cpp
+++ b/src/game/server/gamemodes/microgames/target.cpp
@@ -23,7 +23,7 @@ void MGTarget::Start()
 		Char->SetHitOthers(false);
 		Char->SetCollideOthers(false);
 		
-		for (int j=0; j<4; j++)
+		for (int j=1; j<4; j++)
 			Char->GiveWeapon(weapons[j], 3);
 		Char->SetWeapon(weapons[rand() % 4]);
 		
@@ -51,7 +51,7 @@ void MGTarget::End()
 		CCharacter *Char = GameServer()->GetPlayerChar(i);
 		if (not Char) continue;
 
-		for (int j=0; j<4; j++)
+		for (int j=1; j<4; j++)
 			Char->SetWeaponGot(weapons[j], false);
 
 		Char->SetWeapon(WEAPON_HAMMER);

--- a/src/game/server/gamemodes/microgames/target.cpp
+++ b/src/game/server/gamemodes/microgames/target.cpp
@@ -3,6 +3,9 @@
 #include <engine/shared/config.h>
 #include "target.h"
 
+const int weapons[4] = { WEAPON_GUN, WEAPON_GRENADE, WEAPON_SHOTGUN, WEAPON_RIFLE };
+const char *weaponNames[4] = { "PISTOL", "GRENADES", "SHOTGUN", "LASER" };
+
 MGTarget::MGTarget(CGameContext* pGameServer, CGameControllerWarioWare* pController) : Microgame(pGameServer, pController)
 {
 	m_microgameName = "target";
@@ -20,20 +23,24 @@ void MGTarget::Start()
 		Char->SetHitOthers(false);
 		Char->SetCollideOthers(false);
 		
-		Char->GiveWeapon(WEAPON_RIFLE, -1);
-		Char->SetWeapon(WEAPON_RIFLE);
+		for (int j=0; j<4; j++)
+			Char->GiveWeapon(weapons[j], 3);
+		Char->SetWeapon(weapons[rand() % 4]);
 		
 		Controller()->teleportPlayer(i, 6);
 	}
 
 	// teleport the bot player (the target)
+	m_UseWeapon = rand() % 4;
 	int bot_tele = 7;
 	int Num = Controller()->m_TeleOuts[bot_tele-1].size();
 	Server()->SetClientName(MAX_CLIENTS-1, "HIT ME");
 	GameServer()->m_apPlayers[MAX_CLIENTS-1]->SetTeam(0, false); // move to game
 	GameServer()->m_apPlayers[MAX_CLIENTS-1]->ForceSpawn(Controller()->m_TeleOuts[bot_tele-1][(!Num)?Num:rand() % Num]);
-	
-	GameServer()->SendBroadcast("Hit the target!", -1);
+
+	char aBuf[128];
+	str_format(aBuf, sizeof(aBuf), "Hit the target with your %s!", weaponNames[m_UseWeapon]);
+	GameServer()->SendBroadcast(aBuf, -1);
 	Controller()->setPlayerTimers(g_Config.m_WwSndMgHitTheTarget_Offset, g_Config.m_WwSndMgHitTheTarget_Length);
 }
 
@@ -44,9 +51,10 @@ void MGTarget::End()
 		CCharacter *Char = GameServer()->GetPlayerChar(i);
 		if (not Char) continue;
 
-		Char->SetWeaponGot(WEAPON_RIFLE, false);
-		if (Char->GetActiveWeapon() == WEAPON_RIFLE and Char->GetLastWeapon() != WEAPON_RIFLE)
-			Char->SetWeapon(Char->GetLastWeapon());
+		for (int j=0; j<4; j++)
+			Char->SetWeaponGot(weapons[j], false);
+
+		Char->SetWeapon(WEAPON_HAMMER);
 
 		Controller()->teleportPlayerToSpawn(i);
 	}
@@ -59,4 +67,19 @@ void MGTarget::End()
 void MGTarget::Tick()
 {
 	// nothing to tick
+}
+
+void MGTarget::OnCharacterDamage(int Victim, int Killer, int Dmg, int Weapon)
+{
+	if (Victim == MAX_CLIENTS-1)
+	{
+		if (Weapon == weapons[m_UseWeapon]) {
+			Controller()->winMicroGame(Killer);
+		} else {
+			if (!Controller()->g_Complete[Killer]) {
+				Controller()->killAndLoseMicroGame(Killer);
+				GameServer()->SendChatTarget(Killer, "You used the wrong weapon...");
+			}
+		}
+	}
 }

--- a/src/game/server/gamemodes/microgames/target.h
+++ b/src/game/server/gamemodes/microgames/target.h
@@ -11,6 +11,8 @@
 
 class MGTarget : public Microgame
 {
+private:
+	int m_UseWeapon;
 public:
 	MGTarget(CGameContext* pGameServer, CGameControllerWarioWare* pController);
 	~MGTarget() {}
@@ -18,6 +20,7 @@ public:
 	void Start();
 	void End();
 	void Tick();
+	void OnCharacterDamage(int Victim, int Killer, int Dmg, int Weapon);
 };
 
 #endif // _MICROGAME_TARGET_H

--- a/src/game/server/gamemodes/microgames/tilecolors.cpp
+++ b/src/game/server/gamemodes/microgames/tilecolors.cpp
@@ -63,8 +63,7 @@ void MGTileColors::Tick()
 			if (m_currColor+185 != TileIndex) // first color begins at entity 185
 			{
 				// they're not inside this color, die
-				float timeLeft = Controller()->getTimeLength() - Controller()->getTimer();
-				Char->Die(i, WEAPON_WORLD, timeLeft/1000.f);
+				Controller()->killAndLoseMicroGame(i);
 			}
 			else if (m_turn) // they win
 			{


### PR DESCRIPTION
target: give players all weapons and only allows one type of weapon to hit the target and win.
simon: added "don't" version of prompts.
dontmove: bruteforce-ly added more prompts.
math: added division and pow math (I made sure the pow math is super easy).

or just cherry-pick the ones you like

in the commit for target, i also added a "killAndLoseMicrogame" method in controller which replace sevearl timer calculation and chat->die.